### PR TITLE
Add windows compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,31 +1,49 @@
 cmake_minimum_required(VERSION 3.5)
 project(Roborobo.4)
-set(CMAKE_BUILD_TYPE Debug)
 
-if (NOT DEFINED CMAKE_BUILD_TYPE)
-    set(CMAKE_BUILD_TYPE Debug)
+if (MSVC)
+    add_compile_options(
+        /EHsc # enable exceptions
+        /wd4820 # disable padding warning
+        /wd4365 # disable signed/unsigned warning
+        /wd4244 # disable narrowing warning
+        /wd4100 # disable unreferenced variable warning
+        /wd5045 # disable strange python warning
+        /wd4242 # disable type conversion warning
+        /wd4623 # disable constructor implicit deleted warning
+        /wd4626 # disable operator implicit deleted warning
+        /wd4245 # disable return type conversion warning
+        /wd4458 # disable hiding class member warning
+        /wd4266 # disable no override available warning
+        /wd4068 # disable unknown pragma warning
+        /wd4456 # disable declaration hides previous local declaration warning
+        /wd4868 # disable compiler may not enforce left-to-right evaluation warning
+        /wd4866 # disable compiler may not enforce left-to-right evaluation warning
+        /wd4189 # disable local variable is initialized but not referenced warning
+        /wd4514 # disable unreferenced inline function has been removed warning
+        /wd4101 # disable unreferenced local variable warning
+        /wd4800 # disable implicit conversion warning
+        /wd5039 # disable pointer or reference warning
+        /wd4267 # disable conversion warning
+        /wd4996 # disable unsafe function or variable warning
+        /wd4459 # disable hides global declaration warning
+        /wd4702 # disable unreachable code warning
+        /wd5219 # disable implicit conversion warning
+        /wd4996 # disable deprecation warning
+        /WX- # disable "warning treaded as error"
+        )
 endif ()
-message("Type of build: " ${CMAKE_BUILD_TYPE})
+
 set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_FLAGS "-Wall -O3")
 
-#SET(PYTHON_EXECUTABLE /...path_to_python_exec.../python)
-
-if (DEFINED ENV{PYTHON_EXECUTABLE})
-    SET(PYTHON_EXECUTABLE $ENV{PYTHON_EXECUTABLE})
-    message(${PYTHON_EXECUTABLE})
-else ()
-    message("PYTHON_EXECUTABLE environment variable is not set")
-endif ()
-
-if (DEFINED ENV{CONDA_PREFIX})
-    message("Conda env found, using " $ENV{CONDA_PREFIX})
-    list(APPEND CMAKE_MODULE_PATH "$ENV{CONDA_PREFIX}/share/cmake/")
-    set(pybind11_DIR "$ENV{CONDA_PREFIX}/share/cmake/pybind11")
+if (MSVC)
+    add_compile_options(/O2)
 else()
-    message("No conda environment found")
+    add_compile_options(-O3 -Wall)
 endif()
 
+set(PYBIND11_FINDPYTHON ON)
+find_package(Python COMPONENTS Interpreter Development REQUIRED)
 find_package(pybind11 REQUIRED)
 
 get_cmake_property(_variableNames VARIABLES)
@@ -61,39 +79,27 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/")
 #find_package(SDL2 COMPONENTS main image REQUIRED)
 find_package(SDL2 CONFIG REQUIRED)
 find_package(SDL2_image CONFIG REQUIRED)
-find_package(Boost COMPONENTS REQUIRED)
-IF (Boost_FOUND)
-    include_directories(${Boost_INCLUDE_DIR})
-endif ()
-
-if (SDL2_FOUND)
-    include_directories(${SDL2_INCLUDE_DIR})
-endif()
-
-message(${SDL2_LIBRARIES})
-
-
-include_directories(${SDL2_INCLUDE_DIRS})
-
+find_package(Boost REQUIRED COMPONENTS filesystem system)
 
 find_package(Eigen3 REQUIRED NO_MODULE)
 
 add_executable(roborobo ${SOURCE_FILES})
 target_link_libraries(roborobo PRIVATE
-        ${SDL2_LIBRARIES}
-        ${SDL2_IMAGE_LIBRARIES}
-        ${Boost_FILESYSTEM_LIBRARY}
-        ${Boost_SYSTEM_LIBRARY}
-        Eigen3::Eigen
-        )
-
+                      SDL2::SDL2
+                      SDL2::SDL2main
+                      SDL2_image::SDL2_image
+                      Boost::filesystem
+                      Boost::system
+                      Eigen3::Eigen
+)
 
 pybind11_add_module(pyroborobo ${LIB_SOURCE_FILES})
 target_compile_definitions(pyroborobo PUBLIC PYROBOROBO=1)
 target_link_libraries(pyroborobo PRIVATE
-        ${SDL2_LIBRARIES}
-        ${SDL2_IMAGE_LIBRARIES}
-        ${Boost_FILESYSTEM_LIBRARY}
-        ${Boost_SYSTEM_LIBRARY}
-        Eigen3::Eigen
-        )
+                      SDL2::SDL2
+                      SDL2::SDL2main
+                      SDL2_image::SDL2_image
+                      Boost::filesystem
+                      Boost::system
+                      Eigen3::Eigen
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,9 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/")
 
-find_package(SDL2 COMPONENTS main image REQUIRED)
+#find_package(SDL2 COMPONENTS main image REQUIRED)
+find_package(SDL2 CONFIG REQUIRED)
+find_package(SDL2_image CONFIG REQUIRED)
 find_package(Boost COMPONENTS REQUIRED)
 IF (Boost_FOUND)
     include_directories(${Boost_INCLUDE_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,8 @@ project(Roborobo.4)
 if (MSVC)
     add_compile_options(
         /EHsc # enable exceptions
+        # These warnings are temporarily disabled
+        # TODO: Fixing these warnings
         /wd4820 # disable padding warning
         /wd4365 # disable signed/unsigned warning
         /wd4244 # disable narrowing warning

--- a/README.md
+++ b/README.md
@@ -197,13 +197,31 @@ vcpkg integrate install
 #       directory or add the directory to your
 #       PATH
 
-# The second command will return something like:
-# Applied user-wide integration for this vcpkg root.
-# CMake projects should use: "-DCMAKE_TOOLCHAIN_FILE=<vpk-repo-path>/scripts/buildsystems/vcpkg.cmake"
-# All MSBuild C++ projects can now #include any installed libraries. Linking will be handled automatically. Installing new libraries will make them instantly available.
+# ============================================
+#                DON'T SKIP THIS
+# ============================================
+# Now open up your system or user environment
+# variables:
+# 1. press Windows Key
+# 2. "Edit the system environment variables" or 
+#    "Edit environment variables for your user"
+# 3. press "Environment Variables..."
+# 4. press "New" (be cautions if you press the
+#    top or the bottom button, depending of if
+#    you want to have it for the user or system
+#    wide)
+#    Note: Since the vcpkg repository is probably
+#          only accessible for your user, it makes
+#          more sense to make this only for your
+#          user account.
 #
-# Now use this information to execute this command in your console before doing the next step:
-setx CMAKE_PREFIX_PATH "<vcpkg-repo-path>/installed/x64-windows"
+#    Variable name: CMAKE_PREFIX_PATH
+#    Variable content: <vcpkg-repo-path>/installed/x64-windows
+#
+#    Note: Replace "<vcpkg-repo-path>" with the
+#          actual path.
+#    Note: If you have a x86 system, the path might
+#          be different.
 ```
 
 Now install `roborobo4`:
@@ -214,6 +232,8 @@ git clone https://github.com/nekonaute/roborobo4.git
 cd <some-path>/roborobo4
 
 # Set compile mode to release
+# Note: For some reason a debug build
+#       did not work on Windows.
 set CMAKE_BUILD_TYPE=Release
 
 py -m pip install . --force --user -v --no-build-isolation

--- a/README.md
+++ b/README.md
@@ -6,51 +6,55 @@
 
 ## Version
 
-Roborobo version 4 is currently the __only__ supported version. Current official release is (from: *roborobo.cpp*):
- * *gVersion = 20210321*
- * *gCurrentBuildInfo = Shangri-La build*
+Roborobo version 4 is currently the **only** supported version. Current official release is (from: _roborobo.cpp_):
+
+* _gVersion = 20210321_
+* _gCurrentBuildInfo = Shangri-La build_
 
 ## Contributors
 
-__Main contributors__
+### Main contributors
 
- * Nicolas Bredeche: main roborobo developper and project initiator (since 2009)
- * [http://pages.isir.upmc.fr/~bredeche/](https://www.isir.upmc.fr/personnel/bredeche/?lang=en)
- * contact: nicolas.bredeche(at)sorbonne-universite.fr
+* Nicolas Bredeche: main roborobo developper and project initiator (since 2009)
+* [http://pages.isir.upmc.fr/~bredeche/](https://www.isir.upmc.fr/personnel/bredeche/?lang=en)
+* contact: nicolas.bredeche(at)sorbonne-universite.fr
 
- * Paul Ecoffet: pyRoborobo, the python interface to Roborobo (2020-2021)
- * Evert Haasdijk: properties management library (2010-2012)
+* Paul Ecoffet: pyRoborobo, the python interface to Roborobo (2020-2021)
+* Evert Haasdijk: properties management library (2010-2012)
 
-__Other contributors__
+### Other contributors
 
- * Jean-Marc Montanier, Berend Weel, Amine Boumaza, Andreas Steyven, Leo Cazenille, Theotime Grohens, and a few others!
+* Jean-Marc Montanier, Berend Weel, Amine Boumaza, Andreas Steyven, Leo Cazenille, Theotime Grohens, and a few others!
 
 ## How to cite Roborobo in your work
 
-If you use __Roborobo__ in your work, __please cite the following paper__:
+If you use **Roborobo** in your work, **please cite the following paper**:
 
-*N. Bredeche, J.-M. Montanier, B. Weel, and E. Haasdijk. Roborobo! a fast robot simulator for swarm and collective robotics. CoRR, abs/1304.2888, 2013.*
+_N. Bredeche, J.-M. Montanier, B. Weel, and E. Haasdijk. Roborobo! a fast robot simulator for swarm and collective robotics. CoRR, abs/1304.2888, 2013._
 
-Link to the paper on Arxiv: http://arxiv.org/abs/1304.2888 
+Link to the paper on Arxiv: [Arxiv 1304.2888](http://arxiv.org/abs/1304.2888)
 
-_Scientific papers that cite Roborobo_: https://scholar.google.fr/scholar?cites=7785979290259259170
+_Scientific papers that cite Roborobo_: [Scholar Citation 7785979290259259170](https://scholar.google.fr/scholar?cites=7785979290259259170)
 
 ___
-# INSTALLATION
 
-Roborobo basic dependencies are: 
+## INSTALLATION
+
+Roborobo basic dependencies are:
+
 * a C++ compiler (GCC or CLANG)
 * Python 3.x
 
 Supported platforms:
- * Linux-based
- * MacOS X
+
+* Linux-based
+* MacOS X
 
 Linux, Windows and MacOS installation instructions are described below. Other platforms are not officially supported, but Roborobo was previously shown to run on: Raspbian and Pandora.
 
 _Remark: if you get a lot of warnings during compilation, this is probably due to already installed pip packages shadowing the newly installed conda packages (e.g. with pybind). Work around for pyBind that may work: conda install -c conda-forge "pybind11>2.6". However the best way is to delete the pip packages and make a clean install of roborobo again__
 
-## Linux
+### Linux
 
 Create a conda environment:
 
@@ -59,7 +63,7 @@ conda create --name roborobo numpy pybind11
 conda activate roborobo
 ```
 
-Install Python dependencies for Roborobo (numpy, pybind11, sphinx, ...) 
+Install Python dependencies for Roborobo (numpy, pybind11, sphinx, ...)
 
 ```bash
 conda install numpy setuptools
@@ -96,7 +100,7 @@ python3 -m pip install . --force --user -v
 
 Check the QUICK START section below for running a Roborobo example.
 
-## Mac OS
+### Mac OS
 
 Create a conda environment:
 
@@ -145,7 +149,7 @@ python3 -m pip install . --force --user -v
 
 Check the QUICK START section below for running a Roborobo example.
 
-## Windows
+### Windows
 
 First you need python 3.12 with the corresponding packages:
 
@@ -283,7 +287,7 @@ py -m pip install . --force --user -v --no-build-isolation
 
 Check the QUICK START section below for running a Roborobo example.
 
-### Checking Python Package Contents
+#### Checking Python Package Contents
 
 To check the content of the roborobo package, open up the `x64 Native Tools Command Prompt for VS 2022`. There you can execute:
 
@@ -296,20 +300,30 @@ dumpbin /dependents "%APPDATA%\Python\Python313\site-packages\pyroborobo.cp313-w
 #       <python-path>\site-packages\pyroborobo.cp<python-version>-win_<architecture>.pyd
 ```
 
-## Uninstalling RoboRobo if needed
+### Uninstalling RoboRobo if needed
 
 ```bash
+# Navigate to the roborobo repo in your console of choice
+cd <roborobo-repo-path>
+
+# Delete directories with compile artifacts
+rmdir /s /q build
+rmdir /s /q roborobo.egg-info
+
+# Uninstall the module
 pip uninstall roborobo -y
 ```
 
 ___
-# QUICK START
 
-It is highly suggested to use the __python__ interface to Roborobo, which we refer to as __pyRoborobo__. If you prefer to develop your project in C++, it also possible (check below). pyRoborobo is built as an interface to Roborobo, and though there is of course a cost to use Python instead of pure C++, we empirically consider it worth the ease of development in the context of academic research. For example, the Boids example runs at ~400 fps (pure C++) and ~200 fps (pyRoborobo) on a Macbook pro 13 (early 2019 model).
+## QUICK START
 
-Roborobo (C++) and pyRoborobo (Python) both uses three important directories, that should be accessible from where your code (C++ binary or python script) is run. 
+It is highly suggested to use the **python** interface to Roborobo, which we refer to as **pyRoborobo**. If you prefer to develop your project in C++, it also possible (check below). pyRoborobo is built as an interface to Roborobo, and though there is of course a cost to use Python instead of pure C++, we empirically consider it worth the ease of development in the context of academic research. For example, the Boids example runs at ~400 fps (pure C++) and ~200 fps (pyRoborobo) on a Macbook pro 13 (early 2019 model).
+
+Roborobo (C++) and pyRoborobo (Python) both uses three important directories, that should be accessible from where your code (C++ binary or python script) is run.
+
 * **_data_** contains image and resources for setting a roborobo environment
-* **_config_** contains configuration files for running a roborobo environment 
+* **_config_** contains configuration files for running a roborobo environment
 * **_logs_** will contain log files generated during a roborobo run
 
 While running an example, type "h" when the focus is on the Roborobo window. Help tips will be displayed in the console.
@@ -317,11 +331,13 @@ While running an example, type "h" when the focus is on the Roborobo window. Hel
 ## Running a Python example
 
 Activate conda environment (if not done already):
+
 ```bash
 conda activate roborobo
 ```
 
 Compile and install Roborobo (if not done already):
+
 ```bash
 cd <your_roborobo_folder>
 # python setup.py clean --all -- only if want to rebuild all from scratch
@@ -336,7 +352,7 @@ cd <your_roborobo_folder>/pyRoborobo_dev/examples/
 python tutorial.py
 ```
 
-Many other examples are available in the __pyRoborobo_dev/examples__ folder.
+Many other examples are available in the **pyRoborobo_dev/examples** folder.
 
 ## Build the pyRoborobo API documentation (optional)
 
@@ -351,7 +367,7 @@ The pyRoborobo API documentation is now in _build/sphinx/html/index.html_
 
 ## Running a C++ example (optional)
 
-If you installed Roborobo for the first time, setup the directory structure for running Roborobo: 
+If you installed Roborobo for the first time, setup the directory structure for running Roborobo:
 
 Setup the directory structure for both C++ and Python development (done only once):
 
@@ -364,11 +380,13 @@ ln -s ../logs
 ```
 
 Activate conda environment (if not done already):
+
 ```bash
 conda activate roborobo
 ```
 
-Compile and install Roborobo (to be done every time you modify the C++ code:
+Compile and install Roborobo (to be done every time you modify the C++ code):
+
 ```bash
 cd <your_roborobo_folder>
 # python setup.py clean --all --user _only if want to rebuild all from scratch_
@@ -387,54 +405,55 @@ Roborobo (C++) examples are in the <your_roborobo_folder>/prj directory. Note th
 
 ## What next?
 
- * Check _OVERVIEW.TXT for a __quick introduction__.
- * Check _FAQ.TXT for __trouble shooting__ and __frequently asked questions__.
- * Check the examples, and learn by doing.
+* Check _OVERVIEW.TXT for a **quick introduction**.
+* Check _FAQ.TXT for **trouble shooting** and **frequently asked questions**.
+* Check the examples, and learn by doing.
 
 ## Troubleshooting
 
 Roborobo is regularly tested on the most recent Ubuntu LTS. While you should not encounter any problems with an up-to-date Linux distribution, it may be different with non-standard, outdated and/or badly managed Linux distributions. The following covers the most common errors. Note that before trying to fix things, you should be 100% sure that you followed _exactly_ the installation steps provided above.
 
- * First, be sure that conda uses the same Python version as the default one used in the terminal.
- 	* To check which versions are used:
-		* for Python in Conda: _conda list | grep python_
-		* for Python in Terminal: _python3 --version_
-	* To force conda to use a specific version of Python: _conda create (...) python==3.12_. Updating conda to the latest version if needed.
- 	* To force that the _python_ or _python3_ alias points to the expected python version, re-define the alias in your profile file. E.g.: with _bash_, edit the .bashrc file and add the following line at the end: _alias python='/usr/bin/python3.xx'_ with _xx_ the preferred version. Restart the terminal after modification.
- * When executing _conda activate roborobo_
-        * error: the shell (e.g. bash) is not configured.
-	* solution 1: _conda init bash_. This may fail if your bash profile has been badly written. Fix: clean your bash profile
-   	* solution 2: use another shell. E.g. _tcsh_. I.e. restart installation from scratch. In the terminal, type _tcsh_ before the command _conda activate roborobo_ (during installation, and afterwards when coding).
- * When executing _python3 -m pip install . --force --user -v_
-	 * => error during execution "could NOT find SDL2" (hidden somewhere in the very long list of messages)
-	 * system install of SDL2 (must be super user). See apt commands above.
- * When executing _python3 -m pip install . --force --user -v_
- 	 * error referring to Sphinx (Sphinx is used for generating the documentation)
-         * easy fix (recommended): remove reference to Sphinx in setup.py (delete line 7 and remove _'build_sphinx': BuildDoc_ from line 64)
-         * easy fix (not recommended): switch to a different version of Python (e.g. away from 3.10) 
- * When executing _python3 -m pip install . --force --user -v_
-	 * error: problem with missing MESA/GLX (this is related to the OpenGL graphic library and its open-source implementation in Linux systems).
-	 * solution (see above): apt-get install -y mesa-utils libgl1-mesa-glx
- * When executing _python setup.py install --force --use -v_
-	 * error: "setup.py install is deprecated." (this should not happen if you follow the tutorial)
-	 * You tried to run setup.py. Contrary to what the message says, setup.py isn't deprecated but can no longer be used directly.
-	 * Solution (see above): python3 -m pip install . --force --user -v
-	 * Comment: it can be pretty long. Be sure to use the -v option for verbose mode.
- * When executing _python setup.py install --force --use -v_
-	 * error: "func.h:55:58: error: expected template-name before '<' token" or "Deprecated function in roborobo4/include/contrib/zsu/func.h, line 55"
-	 * cause: recent compiler may spot a deprecated function in roborobo4/include/contrib/zsu/func.h, line 55
-  	 * solution: roborobo4/include/contrib/zsu/func.h, line 55, replace:
-		* new: class unary_function_binder: public std::__unary_function<_Result, _Arg>
-		* old: class unary_function_binder: public std::unary_function<_Result, _Arg>
- * When executing _python3 tutorial.py_ (or any other examples)
-	 * error: "no module name 'pyRoborobo'"
-  	 * first, be sure to check that you followed every step of the installation tutorial. If this is the case, then try the following.
-  	 * Solution 1: be sure that you have activated the conda environment (prefix of prompt should read something like _(roborobo)_)
-   	 * Solution 2: this may be a tricky problem of mismatch Python versions from Conda and command-line. Use same python versions (i.e.: update Conda, or use specific Python version in command line). Comment: Conda's Python and default Python command uses different versions. Check with _conda list | grep python_ and _python --version_. They should be the same.
- * When executing _python tutorial.py_ (or any other examples)
-	 * error looks like: ImportError: /lib/x86_64-linux-gnu/libwayland-client.so.0: undefined symbol: ffi_type_uint32, version LIBFFI_BASE_7.0
-	 * fix looks like: solution: export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libffi.so.7
- * As of early 2024, Mac M2 does not seem to be able to run Roborobo. You may use Virtualbox to install a Linux OS but this is still in beta for Mac M1/M2 as of early 2024. Check dedicated [topic on virtualbox forum](https://forums.virtualbox.org/viewtopic.php?f=8&t=107344) for updates on the topic. Alternatively, you can use Parallels Desktop (but it is not free).
+* First, be sure that conda uses the same Python version as the default one used in the terminal.
+  * To check which versions are used:
+    * for Python in Conda: _conda list | grep python_
+    * for Python in Terminal: _python3 --version_
+  * To force conda to use a specific version of Python: _conda create (...) python==3.12_. Updating conda to the latest version if needed.
+  * To force that the _python_ or _python3_ alias points to the expected python version, re-define the alias in your profile file. E.g.: with _bash_, edit the .bashrc file and add the following line at the end: _alias python='/usr/bin/python3.xx'_ with _xx_ the preferred version. Restart the terminal after modification.
+* When executing _conda activate roborobo_
+  * error: the shell (e.g. bash) is not configured.
+    * solution 1: _conda init bash_. This may fail if your bash profile has been badly written. Fix: clean your bash profile
+    * solution 2: use another shell. E.g. _tcsh_. I.e. restart installation from scratch. In the terminal, type _tcsh_ before the command _conda activate roborobo_ (during installation, and afterwards when coding).
+* When executing _python3 -m pip install . --force --user -v_
+  * => error during execution "could NOT find SDL2" (hidden somewhere in the very long list of messages)
+  * system install of SDL2 (must be super user). See apt commands above.
+* When executing _python3 -m pip install . --force --user -v_
+  * error referring to Sphinx (Sphinx is used for generating the documentation)
+    * easy fix (recommended): remove reference to Sphinx in setup.py (delete line 7 and remove _'build_sphinx': BuildDoc_ from line 64)
+    * easy fix (not recommended): switch to a different version of Python (e.g. away from 3.10)
+* When executing _python3 -m pip install . --force --user -v_
+  * error: problem with missing MESA/GLX (this is related to the OpenGL graphic library and its open-source implementation in Linux systems).
+    * solution (see above): apt-get install -y mesa-utils libgl1-mesa-glx
+* When executing _python setup.py install --force --use -v_
+  * error: "setup.py install is deprecated." (this should not happen if you follow the tutorial)
+    * You tried to run setup.py. Contrary to what the message says, setup.py isn't deprecated but can no longer be used directly.
+    * Solution (see above): python3 -m pip install . --force --user -v
+    * Comment: it can be pretty long. Be sure to use the -v option for verbose mode.
+* When executing _python setup.py install --force --use -v_
+  * error: "func.h:55:58: error: expected template-name before '<' token" or "Deprecated function in roborobo4/include/contrib/zsu/func.h, line 55"
+    * cause: recent compiler may spot a deprecated function in roborobo4/include/contrib/zsu/func.h, line 55
+    * solution: roborobo4/include/contrib/zsu/func.h, line 55, replace:
+      * new: class unary_function_binder: public std::__unary_function<_Result, _Arg>
+      * old: class unary_function_binder: public std::unary_function<_Result, _Arg>
+* When executing _python3 tutorial.py_ (or any other examples)
+  * error: "no module name 'pyRoborobo'"
+    * first, be sure to check that you followed every step of the installation tutorial. If this is the case, then try the following.
+    * Solution 1: be sure that you have activated the conda environment (prefix of prompt should read something like _(roborobo)_)
+    * Solution 2: this may be a tricky problem of mismatch Python versions from Conda and command-line. Use same python versions (i.e.: update Conda, or use specific Python version in command line). Comment: Conda's Python and default Python command uses different versions. Check with _conda list | grep python_ and _python --version_. They should be the same.
+* When executing _python tutorial.py_ (or any other examples)
+  * error looks like: ImportError: /lib/x86_64-linux-gnu/libwayland-client.so.0: undefined symbol: ffi_type_uint32, version LIBFFI_BASE_7.0
+    * fix looks like: solution: export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libffi.so.7
+* As of early 2024, Mac M2 does not seem to be able to run Roborobo. You may use Virtualbox to install a Linux OS but this is still in beta for Mac M1/M2 as of early 2024. Check dedicated [topic on virtualbox forum](https://forums.virtualbox.org/viewtopic.php?f=8&t=107344) for updates on the topic. Alternatively, you can use Parallels Desktop (but it is not free).
+
 ___
 
 _Thank you for using Roborobo!_

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ First you need python 3.12 with the corresponding packages:
 winget install --id Python.Python.3.13 -e
 
 # Install the packages
-pip install setuptools wheel "sphinx<7"
+pip install setuptools wheel "sphinx<7" pybind11
 ```
 
 Now you need the VS building tools to get CMake and all other tools required:
@@ -169,8 +169,16 @@ winget install -e --id Microsoft.VisualStudio.2022.BuildTools
 # => The "Workloads" and "Individual Components" can be selected
 #    during the installation process.
 
-# In addition you need CMake to use it in the command line:
-winget install -e --id Kitware.CMake
+# ============================================
+#              Choose one Option
+# ============================================
+# 1. Use cmake from VS Build Tools:
+#    1.1. Open `x64 Native Tools Command Prompt for VS 2022`
+#    1.2. Run: where cmake
+#    1.3. Add the path (without `cmake.exe`) to
+#         your PATH of either the user or the system 
+# 2. Install cmake from another source:
+#    winget install -e --id Kitware.CMake
 ```
 
 Install `git`, if not already installed:
@@ -200,7 +208,7 @@ cd vcpkg
 bootstrap-vcpkg.bat -disableMetrics
 
 # Now install all required tools:
-vcpkg install sdl2 sdl2-image
+vcpkg install sdl2 sdl2-image boost-filesystem boost-system boost-multi-array boost-algorithm boost-random boost-serialization boost-thread eigen3 --triplet x64-windows
 vcpkg integrate install
 # Note: You need to run the command in the 
 #       directory or add the directory to your
@@ -231,6 +239,31 @@ vcpkg integrate install
 #          actual path.
 #    Note: If you have a x86 system, the path might
 #          be different.
+# 5. Go to you user or system PATH variable and edit
+#    it. Add a new entry with:
+#    <vcpkg-repo-path>\installed\x64-windows\bin
+#
+# Optional:
+# 6. Add also <vcpkg-repo-path> to PATH, so that you
+#    can use vcpkg as a regular cli program.
+
+# ============================================
+#            Additional Information
+# ============================================
+# 1. You can list all installed components of
+#    vcpkg with:
+#    vcpkg list
+# 2. You can uninstall outdated components with:
+#    vcpkg remove --outdated
+# 3. You can uninstall all components by deleting
+#    the following folders in the vcpkg repo
+#    to make a clear reinstall:
+#     - buildtrees/
+#     - downloads/
+#     - installed/
+#     - packages/
+#    Consider also executing:
+#    vcpkg integrate remove
 ```
 
 Now install `roborobo4`:
@@ -247,6 +280,8 @@ set CMAKE_BUILD_TYPE=Release
 
 py -m pip install . --force --user -v --no-build-isolation
 ```
+
+Check the QUICK START section below for running a Roborobo example.
 
 ### Checking Python Package Contents
 

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ First you need python 3.12 with the corresponding packages:
 winget install --id Python.Python.3.13 -e
 
 # Install the packages
-pip install setuptools wheel sphinx
+pip install setuptools wheel "sphinx<7"
 ```
 
 Now you need the VS building tools to get CMake and all other tools required:
@@ -168,15 +168,24 @@ winget install -e --id Microsoft.VisualStudio.2022.BuildTools
 #  - C++ CMake tools for Windows
 # => The "Workloads" and "Individual Components" can be selected
 #    during the installation process.
+
+# In addition you need CMake to use it in the command line:
+winget install -e --id Kitware.CMake
 ```
 
 Install `git`, if not already installed:
 
 ```bash
 winget install --id Git.Git -e
+
+# If it is already installed, consider this an opportunity
+# to update it with either:
+git update-git-for-windows
+# or
+winget update --id Git.Git -e
 ```
 
-At lase, you need `vcpkg` to install the app at the end:
+At least, you need `vcpkg` to install the app at the end:
 
 ```bash
 # Clone the vcpkg repository from microsoft
@@ -216,7 +225,7 @@ vcpkg integrate install
 #          user account.
 #
 #    Variable name: CMAKE_PREFIX_PATH
-#    Variable content: <vcpkg-repo-path>/installed/x64-windows
+#    Variable content: <vcpkg-repo-path>\installed\x64-windows
 #
 #    Note: Replace "<vcpkg-repo-path>" with the
 #          actual path.
@@ -237,6 +246,19 @@ cd <some-path>/roborobo4
 set CMAKE_BUILD_TYPE=Release
 
 py -m pip install . --force --user -v --no-build-isolation
+```
+
+### Checking Python Package Contents
+
+To check the content of the roborobo package, open up the `x64 Native Tools Command Prompt for VS 2022`. There you can execute:
+
+```bash
+dumpbin /dependents "%APPDATA%\Python\Python313\site-packages\pyroborobo.cp313-win_amd64.pyd"
+
+# Note: The path might be different, depending
+#       on the position of your python installation
+#       and the computer architecture:
+#       <python-path>\site-packages\pyroborobo.cp<python-version>-win_<architecture>.pyd
 ```
 
 ## Uninstalling RoboRobo if needed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Roborobo.4
 
-
 **Roborobo** is a fast and simple 2D mobile robot simulator loosely based on low-cost mobile robots such as khepera or epuck models. It is targeted for fast single and multi-robots simulation for evolutionary robotics and machine learning in multi-agent systems, collective and swarm robotics.
 
 **Roborobo** combines speed of development _and_ speed of execution. Roborobo can be programmed with python 3.x, with all the core functions written in C++ for super fast execution.
@@ -47,10 +46,9 @@ Supported platforms:
  * Linux-based
  * MacOS X
 
-Linux and MacOS installation instructions are described below. Other platforms are not officially supported, but Roborobo was previously shown to run on: MS Windows, Raspbian and Pandora.
+Linux, Windows and MacOS installation instructions are described below. Other platforms are not officially supported, but Roborobo was previously shown to run on: Raspbian and Pandora.
 
 _Remark: if you get a lot of warnings during compilation, this is probably due to already installed pip packages shadowing the newly installed conda packages (e.g. with pybind). Work around for pyBind that may work: conda install -c conda-forge "pybind11>2.6". However the best way is to delete the pip packages and make a clean install of roborobo again__
-
 
 ## Linux
 
@@ -107,7 +105,7 @@ conda create --name roborobo numpy pybind11
 conda activate roborobo
 ```
 
-Install Python dependencies for Roborobo (numpy, pybind11, sphinx, ...) 
+Install Python dependencies for Roborobo (numpy, pybind11, sphinx, ...)
 
 ```bash
 conda install numpy setuptools
@@ -146,6 +144,87 @@ python3 -m pip install . --force --user -v
 ```
 
 Check the QUICK START section below for running a Roborobo example.
+
+## Windows
+
+First you need python 3.12 with the corresponding packages:
+
+```bash
+# Install python 13
+winget install --id Python.Python.3.13 -e
+
+# Install the packages
+pip install setuptools wheel sphinx
+```
+
+Now you need the VS building tools to get CMake and all other tools required:
+
+```bash
+winget install -e --id Microsoft.VisualStudio.2022.BuildTools
+# The installation DOES NOT need any "Workloads".
+# However you need the following "Individual Components":
+#  - MSVC v143 - VS 2022 C++ x64/x86 build tools (Latest)
+#  - Windows 11 SDK (10.0.26100.7175)
+#  - C++ CMake tools for Windows
+# => The "Workloads" and "Individual Components" can be selected
+#    during the installation process.
+```
+
+Install `git`, if not already installed:
+
+```bash
+winget install --id Git.Git -e
+```
+
+At lase, you need `vcpkg` to install the app at the end:
+
+```bash
+# Clone the vcpkg repository from microsoft
+git clone https://github.com/microsoft/vcpkg
+
+# Install vcpkg.
+# Note: You need to run this in a CMD terminal!
+cd vcpkg
+# You can also not use the flag `-disableMetrics`,
+# in case you want Microsoft to collect some usage
+# data.
+bootstrap-vcpkg.bat -disableMetrics
+
+# Now install all required tools:
+vcpkg install sdl2 sdl2-image
+vcpkg integrate install
+# Note: You need to run the command in the 
+#       directory or add the directory to your
+#       PATH
+
+# The second command will return something like:
+# Applied user-wide integration for this vcpkg root.
+# CMake projects should use: "-DCMAKE_TOOLCHAIN_FILE=<vpk-repo-path>/scripts/buildsystems/vcpkg.cmake"
+# All MSBuild C++ projects can now #include any installed libraries. Linking will be handled automatically. Installing new libraries will make them instantly available.
+#
+# Now use this information to execute this command in your console before doing the next step:
+setx CMAKE_PREFIX_PATH "<vcpkg-repo-path>/installed/x64-windows"
+```
+
+Now install `roborobo4`:
+
+```bash
+# Get your local copy of Roborobo:
+git clone https://github.com/nekonaute/roborobo4.git
+cd <some-path>/roborobo4
+
+# Set compile mode to release
+set CMAKE_BUILD_TYPE=Release
+
+py -m pip install . --force --user -v --no-build-isolation
+```
+
+## Uninstalling RoboRobo if needed
+
+```bash
+pip uninstall roborobo -y
+```
+
 ___
 # QUICK START
 
@@ -185,13 +264,13 @@ Many other examples are available in the __pyRoborobo_dev/examples__ folder.
 ## Build the pyRoborobo API documentation (optional)
 
 Build Roborobo's python API documentation:
+
 ```bash
 # conda activate roborobo (if not already activated)
 python setup.py build_sphinx
 ```
 
 The pyRoborobo API documentation is now in _build/sphinx/html/index.html_
-
 
 ## Running a C++ example (optional)
 

--- a/include/contrib/zsu/func.h
+++ b/include/contrib/zsu/func.h
@@ -49,18 +49,16 @@ namespace zsu
     std::string::iterator i = std::find_if(str.begin(), str.end(), pred);
     // i now points to the 4th character in str; i.e. the first space
   \endcode
-
  */
 template <class _Result, class _Arg>
-class unary_function_binder: public std::unary_function<_Result, _Arg> // might be deprecated. In that case comment this line, uncommented the one below
-//class unary_function_binder: public std::__unary_function<_Result, _Arg>
+class unary_function_binder
 {
   public:
-    typedef _Result (*_Function)(_Arg);
+    using _Function = _Result (*)(_Arg);
 
-    unary_function_binder(_Function __f) {__function = __f;}
+    explicit unary_function_binder(_Function f) : __function(f) {}
 
-    _Result operator() (_Arg __arg) {  return __function(__arg); }
+    _Result operator() (_Arg arg) const {  return __function(arg); }
 
   private:
     _Function __function;

--- a/include/core/RoboroboMain/common.h
+++ b/include/core/RoboroboMain/common.h
@@ -32,6 +32,7 @@
 #include <map>
 #include <string>
 #include <iomanip>
+#define _USE_MATH_DEFINES // enable MSVC math constants for cmath (i. e. M_PI)
 #include <cmath>
 #include <float.h> // for DBL_MAX
 #include <random> 

--- a/include/core/Utilities/CrossPlatformTime.h
+++ b/include/core/Utilities/CrossPlatformTime.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#ifdef _WIN32
+    #include <winsock2.h>
+    #include <windows.h>
+
+    inline int gettimeofday(timeval* tv, void*) {
+        FILETIME ft;
+
+        GetSystemTimeAsFileTime(&ft);
+
+        unsigned long long t = ((unsigned long long)ft.dwHighDateTime << 32) | ft.dwLowDateTime;
+
+        // Convert from 100ns intervals sinc Jan 1 1601
+        t -= 116444736000000000ULL;
+
+        tv->tv_sec = (long)(t / 10000000ULL);
+        tv->tv_usec = (long)((t % 10000000ULL) / 10);
+
+        return 0;
+    }
+#else
+    #include <sys/time.h>
+#endif

--- a/include/core/Utilities/Geometry.h
+++ b/include/core/Utilities/Geometry.h
@@ -9,7 +9,8 @@
 #ifndef GEOMETRY_H
 #define GEOMETRY_H
 
-#include <vector> 
+#include <vector>
+#define _USE_MATH_DEFINES // enable MSVC math constants for cmath (i. e. M_PI)
 #include <math.h> 
 
 #include <string>

--- a/include/core/Utilities/Geometry.h
+++ b/include/core/Utilities/Geometry.h
@@ -16,7 +16,7 @@
 #include <sstream>
 #include <iostream>
 
-#include <sys/time.h>
+#include <core/Utilities/CrossPlatformTime.h>
 
 // A useful struct/class for storing 2D real coordinates.
 class Point2d

--- a/include/core/Utilities/GetOpt.h
+++ b/include/core/Utilities/GetOpt.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <string>
+#include <vector>
+#include <unordered_map>
+
+class GetOpt {
+    public:
+        GetOpt(int argc, char* argv[]);
+
+        bool hasLongOption(const std::string& key) const;
+        bool hasShortOption(char opt) const;
+
+        const char* getLongOptionValue(const std::string& key) const;
+        const char* getShortOptionValue(char opt) const;
+
+        const std::vector<std::string>& getPositionalArgs() const;
+
+    private:
+        std::unordered_map<std::string, std::string> longOptions;
+        std::unordered_map<char, std::string> shortOptions;
+        std::vector<std::string> positionalArgs;
+};

--- a/include/core/Utilities/Misc.h
+++ b/include/core/Utilities/Misc.h
@@ -18,7 +18,7 @@
 #include <cstdlib> // RAND_MAX
 #include <random>
 #include <chrono>
-#include <sys/time.h>
+#include <core/Utilities/CrossPlatformTime.h>
 
 #define swapInteger(a,b) {int tmp;tmp=a;a=b;b=tmp;}
 

--- a/prj/ForagingRegions/src/ForagingRegionsController.cpp
+++ b/prj/ForagingRegions/src/ForagingRegionsController.cpp
@@ -219,7 +219,7 @@ double ForagingRegionsController::getFitness()
             return 0.0; // no fitness (ie. medea) [CTL]
             break;
         case 1: // foraging-only
-        case 4: // naive MO (using foraging and regret as seperate objectives)
+        case 4: // naive MO (using foraging and regret as separate objectives)
             return std::abs(_wm->_fitnessValue); // foraging-only (or naive MO, which uses fitness as foraging)
             break;
         case 2:

--- a/prj/ForagingRegions/src/ForagingRegionsController.cpp
+++ b/prj/ForagingRegions/src/ForagingRegionsController.cpp
@@ -8,6 +8,7 @@
 #include "World/World.h"
 #include "RoboroboMain/roborobo.h"
 #include "WorldModels/RobotWorldModel.h"
+#undef max // Windows fix to use the max function in the normal way
 #include <algorithm>
 
 using namespace Neural;

--- a/prj/ForagingRegions/src/ForagingRegionsController.cpp
+++ b/prj/ForagingRegions/src/ForagingRegionsController.cpp
@@ -174,7 +174,7 @@ void ForagingRegionsController::selectNaiveMO()
 
         for (; fitnessItChallenger != _fitnessValueList.end(); ++fitnessItChallenger, ++regretItChallenger)
         {
-            if ((*fitnessItUnderFocus).second<(*fitnessItChallenger).second and (*regretItUnderFocus).second>(
+            if ((*fitnessItUnderFocus).second<(*fitnessItChallenger).second && (*regretItUnderFocus).second>(
                     *regretItChallenger).second) // remember: regret is positive and larger value is worse.
             {
                 candidate = false;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel", "sphinx"]
+build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools", "wheel", "sphinx"]
+requires = ["setuptools", "wheel", "sphinx", "pybind11"]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import platform
 import re
 import subprocess
 import sys
-from distutils.version import LooseVersion
+from packaging.version import Version
 import pybind11
 
 # Find current python version for API compilation target
@@ -40,8 +40,13 @@ class CMakeBuild(build_ext):
                                ", ".join(e.name for e in self.extensions))
 
         if platform.system() == "Windows":
-            cmake_version = LooseVersion(re.search(r'version\s*([\d.]+)', out.decode()).group(1))
-            if cmake_version < '3.1.0':
+            cmake_version_r_match = re.search(r'version\s*([\d.]+)', out.decode())
+
+            if cmake_version_r_match is None:
+                raise RuntimeError("No CMake version found")
+            
+            cmake_version = Version(cmake_version_r_match.group(1))
+            if cmake_version < Version('3.1.0'):
                 raise RuntimeError("CMake >= 3.1.0 is required on Windows")
 
         for ext in self.extensions:

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,15 @@
 import os
+from os.path import dirname
 import platform
 import re
 import subprocess
 import sys
 from distutils.version import LooseVersion
 import pybind11
+
+# Find current python version for API compilation target
+python_exe = sys.executable
+python_root = dirname(dirname(python_exe))
 
 from setuptools import setup, Extension
 from setuptools.command.build_ext import build_ext
@@ -49,8 +54,14 @@ class CMakeBuild(build_ext):
             extdir += os.path.sep
 
         print(extdir)
-        cmake_args = ['-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=' + extdir,
-                      '-DPYTHON_EXECUTABLE=' + sys.executable]
+        cmake_args = [
+            f'-DCMAKE_LIBRARY_OUTPUT_DIRECTORY={extdir}',
+            f'-DPython_EXECUTABLE={python_exe}',
+            f'-DPYTHON_EXECUTABLE={python_exe}',      # Legacy fallback
+            f'-DPython_ROOT_DIR={python_root}',
+            f'-DPython_FIND_STRATEGY=LOCATION',       # force exact match
+            f'-DPython_FIND_IMPLEMENTATIONS=CPython', # avoid python brought by vcpkg
+        ]
 
         cfg = 'Debug' if self.debug else 'Release'
         build_args = ['--config', cfg]

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,15 @@ class CMakeBuild(build_ext):
             cmake_args += ['-DCMAKE_LIBRARY_OUTPUT_DIRECTORY_{}={}'.format(cfg.upper(), extdir)]
             if sys.maxsize > 2**32:
                 cmake_args += ['-A', 'x64']
+                # For some reason Windows is always defaulting to build the
+                # project with Ninja. This however does not support x64
+                # architectures. Therefore this code will crash without
+                # defining the correct building tool.
+                cmake_args += ['-G', 'Visual Studio 17 2022']
+            # Since `pip install pybind11` only imports the header file
+            # and the program needs the cmake file, you need to give the
+            # installer the concrete location:
+            cmake_args += [f'-Dpybind11_DIR={pybind11.get_cmake_dir()}']
             build_args += ['--', '/m']
         else:
             cmake_args += ['-DCMAKE_BUILD_TYPE=' + cfg]

--- a/setup.py
+++ b/setup.py
@@ -4,17 +4,27 @@ import re
 import subprocess
 import sys
 from distutils.version import LooseVersion
-from sphinx.setup_command import BuildDoc
+import pybind11
 
 from setuptools import setup, Extension
 from setuptools.command.build_ext import build_ext
 
+# For some reason python sometimes complains
+# about a direct import of `sphinx.setup_command`.
+# Therefore this function imports it only when
+# needed. This resolves this issue and makes the
+# script runnable on WSL.
+def get_build_sphinx_class():
+    try:
+        from sphinx.setup_command import BuildDoc
+        return BuildDoc
+    except ImportError:
+        return None
 
 class CMakeExtension(Extension):
     def __init__(self, name, sourcedir=''):
         Extension.__init__(self, name, sources=[])
         self.sourcedir = os.path.abspath(sourcedir)
-
 
 class CMakeBuild(build_ext):
     def run(self):
@@ -61,11 +71,10 @@ class CMakeBuild(build_ext):
         subprocess.check_call(['cmake', ext.sourcedir] + cmake_args, cwd=self.build_temp, env=env)
         subprocess.check_call(['cmake', '--build', '.'] + build_args, cwd=self.build_temp)
 
-cmdclass = {'build_sphinx': BuildDoc, "build_ext":CMakeBuild}
+cmdclass = {'build_sphinx': get_build_sphinx_class(), "build_ext":CMakeBuild}
 name = 'roborobo'
 version = '4.0.0'
 release = '4.0.0'
-
 
 setup(
     name=name,
@@ -84,6 +93,7 @@ setup(
             'project': ('setup.py', name),
             'version': ('setup.py', version),
             'release': ('setup.py', release),
-            'source_dir': ('setup.py', 'docs')}},
-
+            'source_dir': ('setup.py', 'docs')
+        }
+    },
 )

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,9 @@ class CMakeBuild(build_ext):
             f'-DPython_FIND_IMPLEMENTATIONS=CPython', # avoid python brought by vcpkg
         ]
 
-        cfg = 'Debug' if self.debug else 'Release'
+        # Checks if the current python installation is debug capable
+        is_debug_python = hasattr(sys, "gettotalrefcount")
+        cfg = 'Debug' if is_debug_python else 'Release'
         build_args = ['--config', cfg]
 
         if platform.system() == "Windows":

--- a/src/core/GetOpt.cpp
+++ b/src/core/GetOpt.cpp
@@ -1,0 +1,70 @@
+/* This class shall be used to get
+ * options from an cli call. This
+ * variant shall serve as a light
+ * weight option which does not
+ * require external libraries and
+ * is cross platform capable.
+ */
+
+#include "Utilities/GetOpt.h"
+#include <string>
+#include <vector>
+#include <optional>
+#include <unordered_map>
+#include <iostream>
+
+GetOpt::GetOpt(int argc, char* argv[]) {
+    for (int i = 1; i < argc; ++i) {
+        std::string arg = argv[i];
+        
+        // Parse long options
+        if (arg.rfind("--", 0) == 0) {
+            std::string key = arg.substr(2);
+            std::string value;
+
+            if (i + 1 < argc && argv[i+1][0] != '-') {
+                value = argv[i+1];
+                ++i;
+            }
+
+            longOptions[key] = value;
+        // Parse short options
+        } else if (arg[0] == '-') {
+            for (size_t j = 1; j < arg.size(); ++j) {
+                shortOptions[arg[j]] = "";
+            }
+        // Parse positional argument
+        } else {
+            positionalArgs.push_back(arg);
+        }
+    }
+}
+
+bool GetOpt::hasLongOption(const std::string& key) const {
+    return longOptions.find(key) != longOptions.end();
+}
+
+bool GetOpt::hasShortOption(char opt) const {
+    return shortOptions.find(opt) != shortOptions.end();
+}
+
+const char* GetOpt::getLongOptionValue(const std::string& key) const {
+    auto it = longOptions.find(key);
+    if (it == longOptions.end())
+        return nullptr;
+    return it->second.c_str();
+}
+
+const char* GetOpt::getShortOptionValue(char opt) const {
+    auto it = shortOptions.find(opt);
+
+    if (it == shortOptions.end()) {
+        return nullptr;
+    }
+
+    return it->second.c_str();
+}
+
+const std::vector<std::string>& GetOpt::getPositionalArgs() const {
+    return positionalArgs;
+}

--- a/src/core/Misc.cpp
+++ b/src/core/Misc.cpp
@@ -12,6 +12,7 @@
 #include "RoboroboMain/common.h"
 #include <string>
 #include <random>
+#undef max // Windows fix to use the max function in the normal way
 
 // random generator functions, header declaration in common.h (general scope)
 std::random_device rnd;

--- a/src/core/World.cpp
+++ b/src/core/World.cpp
@@ -14,6 +14,8 @@
 #include "Observers/WorldObserver.h"
 #include <iostream>
 #include <vector>
+#include <numeric>
+#include <algorithm>
 
 //#include "tbb/blocked_range.h"
 //#include "tbb/parallel_for.h"
@@ -181,14 +183,9 @@ void World::updateWorld(const Uint8 *_keyboardStates)
 
     // * update physical object, if any (in random order)
 
-    int shuffledObjectIndex[gNbOfPhysicalObjects];
-    for (int i = 0; i < gNbOfPhysicalObjects; i++)
-    {
-        shuffledObjectIndex[i] = i;
-    }
-
-    std::shuffle(&shuffledObjectIndex[0], &shuffledObjectIndex[gNbOfPhysicalObjects], engine);
-    //std::random_shuffle(&shuffledObjectIndex[0], &shuffledObjectIndex[gNbOfPhysicalObjects]); // [!n] remove after 2018-5-1 - random_shuffle was not seeded, and uses rand() - thanks Amine.
+    std::vector<int> shuffledObjectIndex(gNbOfPhysicalObjects); 
+    std::iota(shuffledObjectIndex.begin(), shuffledObjectIndex.end(), 0);
+    std::shuffle(shuffledObjectIndex.begin(), shuffledObjectIndex.end(), engine);
 
     for (int i = 0; i < gNbOfPhysicalObjects; i++)
     {
@@ -208,16 +205,9 @@ void World::updateWorld(const Uint8 *_keyboardStates)
 
     // * update agents
 
-    int shuffledRobotIndex[gNbOfRobots];
-    for (int i = 0; i < gNbOfRobots; i++)
-    {
-        shuffledRobotIndex[i] = i;
-    }
-
-    std::shuffle(&shuffledRobotIndex[0], &shuffledRobotIndex[gNbOfRobots], engine);
-    //std::random_shuffle(&shuffledRobotIndex[0], &shuffledRobotIndex[gNbOfRobots]); // [!n] remove after 2018-5-1 - random_shuffle was not seeded, and uses rand() - thanks Amine.
-
-
+    std::vector<int> shuffledRobotIndex(gNbOfRobots);
+    std::iota(shuffledRobotIndex.begin(), shuffledRobotIndex.end(), 0);
+    std::shuffle(shuffledRobotIndex.begin(), shuffledRobotIndex.end(), engine);
 
     // update agent level observers
     for (int i = 0; i != gNbOfRobots; i++)

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -10,6 +10,7 @@
 #include <cstdlib>
 #include "Utilities/GetOpt.h"
 #include <csignal>
+#include <filesystem>
 
 // For getopt
 extern char *optarg;
@@ -169,8 +170,10 @@ int main(int argc, char* argv[])
     /**/
     char *path = nullptr;
     size_t size = 0;
-    path = getcwd(path,size);
-    std::cout << "[INFO] Current location : " << path << std::endl;
+    //path = getcwd(path,size);
+    std::cout << "[INFO] Current location : "
+              << std::filesystem::current_path().string()
+              << std::endl;
     //delete path;
     /**/
     

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -4,13 +4,11 @@
  *
  *  Created by Nicolas on 16/01/09.
  *  See roborbo.cpp for description
- *
  */
 
 #include "RoboroboMain/main.h"
 #include <cstdlib>
-#include <getopt.h>
-#include <unistd.h>
+#include "Utilities/GetOpt.h"
 #include <csignal>
 
 // For getopt
@@ -85,22 +83,19 @@ std::ostream& operator<<(std::ostream& os, const std::vector<T>& v)
 /** default demo mode with visualization. If at least one argument, launch demo in batch mode (ie. no display, fast pace). */
 int main(int argc, char* argv[])
 {
+    // Parse Command line parameters (in argv), using self-implemented GetOpt
+    GetOpt opt(argc, argv);
     bool commandline_propertiesfilename = false;
     
 	// Install signal handler, to handle Ctrl-C and 'kill' signals
 	signal(SIGINT, quit);
 	signal(SIGTERM, quit);
     
-    // Parse Command line parameters (in argv), using getopt
-    
     displayGeneralInformation();
-    
-    int c = getopt (argc, argv, "vhsl:o:");
-    
-    if ( c  == -1 ) // no arguments? display usage.
+
+    // no arguments? display usage.
+    if (argc == 1)
     {
-        //usage(argv[0]);
-        
         std::cout << "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=" << std::endl;
         std::cout << "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=" << std::endl;
         std::cout << "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=" << std::endl;
@@ -128,71 +123,47 @@ int main(int argc, char* argv[])
         
         //return -1;
     }
-    
-    while ( c  != -1 )
-    {
-        //std::cout << "Argument: " << (int)c << " ; " << (char)c << std::endl; //todo :: DEBUG
-        
-        switch (c)
-        {
-            case 'v':
-                versionInfos();
-                return -1;
-                break;
-                
-            case 'l':
-                if ( commandline_propertiesfilename == false )
-                {
-                    gPropertiesFilename = optarg;
-                    std::cout << "[INFO] Command-line parameter: properties will be loaded from file \"" << gPropertiesFilename << "\"." << std::endl;
-                    commandline_propertiesfilename = true;
-                }
-                else
-                {
-                    std::cout << "[INFO] Command-line parameter: properties file already set (\"" <<  gPropertiesFilename << "\"). Ignored." << std::endl;
-                }
-                break;
-                
-            case 'o':
-                if ( gLogDirectoryname_commandlineargument == false ) // take only the first into account
-                {
-                    gLogDirectoryname = optarg;
-                    std::cout << "[INFO] Command-line parameter: logs will be written in directory \"" <<  gLogDirectoryname << "\" (assume: directory exists)." << std::endl;
-                    gLogDirectoryname_commandlineargument = true;
-                }
-                else
-                {
-                    std::cout << "[INFO] Command-line parameter: logs directory already set (\"" <<  gLogDirectoryname << "\"). Ignored." << std::endl;
-                }
-                break;
-                
-            case 's':
-                gVerbose = false;
-                gVerbose_commandlineargument = true;
-                break;
-                
-            case 'h':
-                usage(argv[0]);
-                return -1;
-                break;
-            
-            case 'b':
-                gBatchMode = true;
-                gDisplayMode = 2;
-                gBatchMode_commandlineargument = true;
-                break;
 
-            case '?':
-                //std::cout << "[INFO] Unknown argument \"" << (char)optopt << "\" detected, and ignored." << std::endl;
-                break;
-                
-            default:
-                usage(argv[0]);
-                return -1;
-                break;
+    if (opt.hasShortOption('v') || opt.hasLongOption("version")) {
+        versionInfos();
+        return -1;
+    }
+
+    if (opt.hasShortOption('h') || opt.hasLongOption("help")) {
+        usage(argv[0]);
+        return -1;
+    }
+
+    if (opt.hasShortOption('s')) {
+        gVerbose = false;
+        gVerbose_commandlineargument = true;
+    }
+
+    if (opt.hasShortOption('b')) {
+        gBatchMode = true;
+        gDisplayMode = 2;
+        gBatchMode_commandlineargument = true;
+    }
+
+    if (auto lval = opt.getShortOptionValue('l')) {
+        if (!commandline_propertiesfilename) {
+            gPropertiesFilename = *lval;
+            std::cout << "[INFO] Command-line parameter: properties will be loaded from file \"" << gPropertiesFilename << "\"." << std::endl;
+            commandline_propertiesfilename = true;
+        } else {
+            std::cout << "[INFO] Command-line parameter: properties file already set (\"" <<  gPropertiesFilename << "\"). Ignored." << std::endl;
         }
-        
-        c = getopt (argc, argv, "vhsbl:o:");
+    }
+
+    if (auto oval = opt.getShortOptionValue('o')) {
+        // take only the first into account
+        if (gLogDirectoryname_commandlineargument == false ) {
+            gLogDirectoryname = *oval;
+            std::cout << "[INFO] Command-line parameter: logs will be written in directory \"" <<  gLogDirectoryname << "\" (assume: directory exists)." << std::endl;
+            gLogDirectoryname_commandlineargument = true;
+        } else {
+            std::cout << "[INFO] Command-line parameter: logs directory already set (\"" <<  gLogDirectoryname << "\"). Ignored." << std::endl;
+        }
     }
     
     /**/

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -178,10 +178,6 @@ int main(int argc, char* argv[])
     /**/
     
 	std::cout << std::endl << std::endl;
-    
-	int returnValue = 0;
-	returnValue = launchRoborobo();
-    
-	return returnValue;
-}
 
+	return launchRoborobo();
+}

--- a/src/core/roborobo.cpp
+++ b/src/core/roborobo.cpp
@@ -481,7 +481,7 @@ void inspectAtPixel(int xIns, int yIns)
 
     std::cout << "\tvirtual floor sensor: ( " << value << " : " << (int) r << "," << (int) g << "," << (int) b << ")"
               << std::endl;
-    if ( value > 0 and value < 0xFFFFFF )
+    if ( value > 0 && value < 0xFFFFFF )
         std::cout << "\ti.e. Footprint of object #" << ( value - 1 ) << " detected." << std::endl;
     else
         if ( value == 0xFFFFFF )


### PR DESCRIPTION
This change makes the project compatible to run natively on Windows as well. In addition to a general instruction on how to compile this program on Windows devices, this change needed to update the code to be completely Windows compatible. The main changes were:

- Enforce strict C++ syntax (replacing logical `and` with `&&` since it is not available on Windows)
- Use Windows alternative of library `sys/time.h` on Windows and add missing function `gettimeofday` for Windows
- Enable `cmath` constants (like `M_PI`) on Windows
- Disable Windows override of `max`-function
- Replace unsupported inheritance of `std::unary_function<_Result, _Arg>`
- Update legacy code in `CMakeLists.txt` and add certain Windows-only settings
- Update `setup.py` and fix #4
- Replace `shuffle` syntax which is not available on Windows
- Add toml file for clearer Python dependency resolution
- Replace `getopt` library with custom code, since the library does not exists on Windows
- Replace POSIX code, since it is not available on Windows

In addition there are many warnings during the build, which might be fixed in the future. To see the initial errors during Windows compilation clearer, I suppressed these warnings. I left the code that way and added a `TODO` comment there.

## Personal Note

I checked the current setup on two different Windows 11 devices and it worked on both. So I am pretty confident, that the setup is correct. However I only have WSL at hand and no Linux or Mac. @nekonaute please confirm, that these changes do not effect your device, but I do not see any reason why the code should not run on MacOS or Linux.